### PR TITLE
no globals in browserify

### DIFF
--- a/index-browserify.js
+++ b/index-browserify.js
@@ -1,3 +1,4 @@
 require('./lib/angular.min.js');
-
+var angular = window.angular;
+delete window.angular;
 module.exports = angular;


### PR DESCRIPTION
Its a browserify & commonJS best practice to not expose a global when you call `require`.

If anyone was relying on `require('angular')` to expose a global they can manually add it back with

``` js
window.angular = require('angular')
```

Recommend a v2.0.0 release.
