### PR TITLE
require angularjs instead of creating a Function to enable debugging

### DIFF
--- a/custom.js
+++ b/custom.js
@@ -3,15 +3,38 @@ var fs = require('fs'),
 	window = document.parentWindow;
 
 module.exports = function (path) {
-	// read angular source into memory
-	var src = fs.readFileSync(path, 'utf8');
 
-	// replace implicit references
-	src = src.split('angular.element(document)').join('window.angular.element(document)');
-	src = src.split('(navigator.userAgent)').join('(window.navigator.userAgent)');
-	src = src.split('angular.$$csp').join('window.angular.$$csp');
+  var prevAngular, prevDocument, prevNavigator, prevWindow;
 
-	(new Function('window', 'document', src))(window, document);
+  // save global state before
+  prevWindow = global.window;
+  prevDocument = global.document;
+  prevNavigator = global.navigator;
+  prevAngular = global.angular;
+
+  // this enables us to `require` angular's code
+  global.window = window;
+  global.document = document;
+  global.navigator = window.navigator;
+
+  // needed because angular is referenced as angular instead of window.angular
+  global.angular = {
+    $$csp: function() {
+      return window.angular.$$csp.apply(window.angular, arguments);
+    },
+    element: function() {
+      return window.angular.element.apply(window.angular, arguments);
+    }
+  };
+
+  // require angular's code
+  require(path);
+
+  // restore global state
+  global.window = prevWindow;
+  global.document = prevDocument;
+  global.navigator = prevNavigator;
+  global.angular = prevAngular;
 
 	return window.angular;
-}
+};

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 var test = require('tape'),
 	path = require('path'),
-	angular = require('angular'),
+	angular = require('../'),
 	inject = angular.injector(['ng']).invoke,
 	version = require(path.resolve('./package.json')).version;
 
@@ -39,8 +39,8 @@ test('injector', function (t) {
 });
 
 test('custom paths', function (t) {
-	var ngUnminified = require('angular/full'),
-		ngCustom = require('angular/custom')(__dirname + '/fixtures/foo.js');
+	var ngUnminified = require('../full'),
+		ngCustom = require('../custom')(__dirname + '/fixtures/foo.js');
 
 	t.equal(ngUnminified.version.full, version, 'Angular unminified and package versions match');
 	t.equal(ngCustom.version.full, version, 'Custom Angular and package versions match');


### PR DESCRIPTION
By setting some variables on global, we can require angularjs instead of creating a new Function and executing it.

That way, angular's code is debugable.

I could not run the tests with `npm test` so I changed the require statements there, e.g. `require('../')` instead of `require('angular')`. Is this ok?
