### PR TITLE
fixed support for current versions of jsdom

### DIFF
--- a/custom.js
+++ b/custom.js
@@ -1,6 +1,6 @@
 var fs = require('fs'),
 	document = require('jsdom').jsdom('<html><head></head><body></body></html>'),
-	window = document.parentWindow;
+	window = document.parentWindow ? document.parentWindow : document.defaultView;
 
 module.exports = function (path) {
 	// read angular source into memory


### PR DESCRIPTION
the current version of jsdom replaces document.parentWindow with document.defaultView, this takes that into account and allows continued use 